### PR TITLE
perf: :zap: Optimize prompt for better caching

### DIFF
--- a/src/ai_hawk/llm/prompts.py
+++ b/src/ai_hawk/llm/prompts.py
@@ -262,16 +262,16 @@ Please write the cover letter in a way that directly addresses the job role and 
 - Do not include any introductions, explanations, or additional information.
 - The letter should be formatted into paragraph.
 
-## Company Name:
-{company}
-
-## Job Description:
-```
-{job_description}
-```
 ## My resume:
 ```
 {resume}
+```
+
+## Company Name:
+{company}
+## Job Description:
+```
+{job_description}
 ```
 """
 
@@ -432,9 +432,9 @@ func_summarize_prompt_template = """
 is_relavant_position_template = """
    Evaluate whether the provided resume meets the requirements outlined in the job description. Determine if the candidate is suitable for the job based on the information provided.
 
-Job Description: {job_description}
-
 Resume: {resume}
+
+Job Description: {job_description}
 
 Instructions:
 1. Extract the key requirements from the job description, identifying hard requirements (must-haves) and soft requirements (nice-to-haves).


### PR DESCRIPTION
Some providers (as OpenAI) support reducing cost of calls by caching repetitive content, but the feature works only with the initial portion (prefix) of prompts.
Keeping repetitive content in the beginning improves caching and reducing costs.
The only change is swap of "My resume" and "Job Description" sections to keep repetitive part first

[OpenAI doc](https://platform.openai.com/docs/guides/prompt-caching)

P.S.
No effect on response is assumed but not tested