### PR TITLE
Fix AttributeError in job suitability reasoning extraction

### DIFF
--- a/src/ai_hawk/llm/llm_manager.py
+++ b/src/ai_hawk/llm/llm_manager.py
@@ -696,7 +696,11 @@ class GPTAnswerer:
         output = self._clean_llm_output(raw_output)
         logger.debug(f"Job suitability output: {output}")
         score = re.search(r"Score: (\d+)", output).group(1)
-        reasoning = re.search(r"Reasoning: (.+)", output, re.DOTALL).group(1)
+        reasoning_match = re.search(r"Reasoning:\s*(.+)", output, re.DOTALL)
+        if reasoning_match:
+            reasoning = reasoning_match.group(1)
+        else:
+            reasoning = ""
         logger.info(f"Job suitability score: {score}")
         if int(score) < JOB_SUITABILITY_SCORE:
             logger.debug(f"Job is not suitable: {reasoning}")


### PR DESCRIPTION
Updated the regular expression pattern to handle optional newline characters when extracting the reasoning.

**Error:**
```
AttributeError: 'NoneType' object has no attribute 'group'
```

**Example LLM Output with Ollama:**
```
Score: 7\nReasoning:\n- The candidate has experience with Node.js, JavaScript, Vue.js, NoSQL, MongoDB, AWS, Jest/Cypress, and automation test skills.\n- The candidate's technical background aligns with the job description requirements for a Senior Full Stack Developer with expertise in these areas.\n- However, the candidate lacks direct experience with AI, machine learning, or open source contribution as required by the job description.
```