### PR TITLE
[BUG]: Not applying to jobs

### DIFF
--- a/src/ai_hawk/job_manager.py
+++ b/src/ai_hawk/job_manager.py
@@ -252,7 +252,7 @@ class AIHawkJobManager:
             pass
 
         try:
-            job_results = self.driver.find_element(By.CLASS_NAME, "jobs-search-results-list")
+            job_results = self.driver.find_element(By.CLASS_NAME, "scaffold-layout__list-detail-container")
             browser_utils.scroll_slow(self.driver, job_results)
             browser_utils.scroll_slow(self.driver, job_results, step=300, reverse=True)
 


### PR DESCRIPTION
Describe the bug

Due to a div name change, the bot is no longer finding jobs on the search page.

Steps to reproduce

![image](https://github.com/user-attachments/assets/f7c3ba9f-fb01-42a3-b584-10a1a944c320)

