### PR TITLE
Remove unused import statement as it causes tkinter error

### DIFF
--- a/src/ai_hawk/job_manager.py
+++ b/src/ai_hawk/job_manager.py
@@ -5,7 +5,6 @@ import time
 from itertools import product
 from pathlib import Path
 import traceback
-from turtle import color
 
 from inputimeout import inputimeout, TimeoutOccurred
 from selenium.common.exceptions import NoSuchElementException


### PR DESCRIPTION
This PR fixes the following error:

```
Traceback (most recent call last):
  File "/home/anders/Project/Auto_Jobs_Applier_AIHawk/main.py", line 27, in <module>
    from ai_hawk.job_manager import AIHawkJobManager
  File "/home/anders/Project/Auto_Jobs_Applier_AIHawk/src/ai_hawk/job_manager.py", line 8, in <module>
    from turtle import color
  File "/usr/lib/python3.12/turtle.py", line 101, in <module>
    import tkinter as TK
ModuleNotFoundError: No module named 'tkinter'
```

by removing the import statement `from turtle import color` from the file, which can be done as the import statement is not being used.

I'm on WSL2 by the way.