### PR TITLE
Fix git clone URL and cd directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ In the digital age, the job search landscape has undergone a dramatic transforma
 3. **Clone the repository:**
 
    ```bash
-   git clone https://github.com/feder-cr/Auto_Jobs_Applier_AIHawk.git
+   git clone https://github.com/code-infected/Auto_Jobs_Applier_AI_Agent.git
    
-   cd Auto_Jobs_Applier_AIHawk
+   cd Auto_Jobs_Applier_AI_Agent
    ```
 
 4. **Activate virtual environment:**


### PR DESCRIPTION
Corrected the git clone URL and cd directory name in the Clone the repository section of the README.md file.

Changes made:
Updated the incorrect git clone URL from:
```

git clone https://github.com/feder-cr/Auto_Jobs_Applier_AIHawk.git
cd Auto_Jobs_Applier_AIHawk
```
****
to the correct one:

```
git clone https://github.com/code-infected/Auto_Jobs_Applier_AI_Agent.git
cd Auto_Jobs_Applier_AI_Agent
```